### PR TITLE
Fix perlcritic failures

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,6 +3,7 @@ Build.PL
 t/00_compile.t
 t/01_smartmatch_operator.t
 t/02_switch_statements.t
+t/99_ensure_perlcritic_instantiates.t
 lib/Perl/Critic/Policy/ProhibitSmartmatch.pm
 lib/Perl/Critic/Policy/ControlStructures/ProhibitSwitchStatements.pm
 lib/Perl/Critic/Policy/Operators/ProhibitSmartmatch.pm

--- a/lib/Perl/Critic/Policy/ProhibitSmartmatch.pm
+++ b/lib/Perl/Critic/Policy/ProhibitSmartmatch.pm
@@ -1,6 +1,9 @@
 package Perl::Critic::Policy::ProhibitSmartmatch;
 
-our $VERSION = '0.2';
+# To keep Perl::Critic from complaining about this documentation
+use parent 'Perl::Critic::Policy';
+
+our $VERSION = '0.21';
 
 =encoding utf-8
 
@@ -20,4 +23,6 @@ Jan Holcapek E<lt>holcapek@gmail.comE<gt>, who was heavily inspired by the work 
 hisaichi5518 E<lt>hisada.kazuki@gmail.comE<gt>
 
 =cut
+
+1;
 

--- a/t/99_ensure_perlcritic_instantiates.t
+++ b/t/99_ensure_perlcritic_instantiates.t
@@ -1,0 +1,13 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Perl::Critic qw(critique);
+
+my $critic = Perl::Critic->new();
+my $src = 'use strict;';
+my (@violations) = $critic->critique( \$src );
+
+ok('Module doesn\'t cause critique to fail');
+
+done_testing;


### PR DESCRIPTION
This is a pretty trivial patch - I'm glad to modify it if needed to get it merged.

Basically, your module is causing the perlcritic executable to die if your module is installed.  I noticed it because it was causing tests on my module to fail: http://www.cpantesters.org/cpan/report/a4b30ab8-d170-11e7-98e7-aa8a7303ad5d

The reason this happened is that Perl::Critic attempts to load all modules in the Perl::Critic::Policy::* namespace.  Despite Perl::Critic::Policy::ProhibitSmartmatch containing no code, Perl::Critic tried to load it.  That failed because there was no new() sub.  By inheriting from Perl::Critic::Policy, that problem is solved.  I'll probably also submit a patch to Perl::Critic to tell it to skip trying to load packages without a new() method, but I think it wise to get this pull request out there, and, ideally, you would push this change fairly quickly as it's impacting unrelated modules simply when your module is installed.

Let me know if you have any questions.